### PR TITLE
feature: Adds labels to suite to differentiate between suits in fern reports

### DIFF
--- a/pkg/client/ginkgo_fern_reporter.go
+++ b/pkg/client/ginkgo_fern_reporter.go
@@ -8,7 +8,7 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/guidewire/fern-ginkgo-client/pkg/models"
+	"client/pkg/models"
 
 	gt "github.com/onsi/ginkgo/v2/types"
 )
@@ -32,9 +32,10 @@ func (f *FernApiClient) Report(testName string, report gt.Report) error {
 			EndTime:         spec.EndTime,
 		}
 
-		// Assuming there is logic to convert spec.Tags to []Tag
-		specRun.Tags = convertTags(spec.Labels())
-
+		// Accessing the suite labels
+		labels := report.SuiteLabels
+		// logic to convert suite labels string to []Tag
+		specRun.Tags = convertTags(labels)
 		specRuns = append(specRuns, specRun)
 	}
 

--- a/tests/adder_suite_test.go
+++ b/tests/adder_suite_test.go
@@ -9,5 +9,5 @@ import (
 
 func TestAdder(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Adder Suite")
+	RunSpecs(t, "Adder Suite", Label("this-is-a-suite-level-label"))
 }


### PR DESCRIPTION

The labels will be shown in Tags in reports : 
<img width="1443" alt="image" src="https://github.com/Guidewire/fern-ginkgo-client/assets/26506546/feeeb4b4-b99e-4edb-b310-76e6fc9be231">
